### PR TITLE
Fix error 'strpos(): Non-string needles will be interpreted as string…

### DIFF
--- a/third_party/MX/Router.php
+++ b/third_party/MX/Router.php
@@ -236,7 +236,7 @@ class MX_Router extends CI_Router
 	public function set_class($class)
 	{
 		$suffix = $this->config->item('controller_suffix');
-		if (strpos($class, $suffix) === FALSE)
+		if ($suffix && strpos($class, $suffix) === FALSE)
 		{
 			$class .= $suffix;
 		}


### PR DESCRIPTION
…s in the future. Use an explicit chr() call to preserve the current behavior'